### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/docker/redis/docker-compose.yml
+++ b/docker/redis/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 
 services:
   redis:
-    image: 'bitnami/redis:6.2.7'
+    image: 'soldevelo/redis:6.2.16'
     container_name: redis
     restart: always
     volumes:


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/redis:6.2.7` → [`soldevelo/redis:6.2.16`](https://hub.docker.com/r/soldevelo/redis)